### PR TITLE
Update to latest AWS IoT Python SDK

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-AWSIoTPythonSDK==1.0.0
+AWSIoTPythonSDK==1.4.9


### PR DESCRIPTION
Fixes error shown below.

```
main  MQTT Thing Starting...
main  Traceback (most recent call last):
main    File "src/main.py", line 57, in <module>
main      mqtt_client.connect()
main    File "/usr/local/lib/python3.6/site-packages/AWSIoTPythonSDK/MQTTLib.py", line 355, in connect
main      return self._mqttCore.connect(keepAliveIntervalSecond)
main    File "/usr/local/lib/python3.6/site-packages/AWSIoTPythonSDK/core/protocol/mqttCore.py", line 282, in connect
main      self._pahoClient.connect(self._host, self._port, keepAliveInterval)  # Throw exception...
main    File "/usr/local/lib/python3.6/site-packages/AWSIoTPythonSDK/core/protocol/paho/client.py", line 655, in connect
main      return self.reconnect()
main    File "/usr/local/lib/python3.6/site-packages/AWSIoTPythonSDK/core/protocol/paho/client.py", line 807, in reconnect
main      self._sock.setblocking(0)
main  OSError: [Errno 9] Bad file descriptor
```